### PR TITLE
Fix GraphQL server exports and startup

### DIFF
--- a/Phase2/.gitignore
+++ b/Phase2/.gitignore
@@ -1,1 +1,2 @@
-// Placeholder for .gitignore
+node_modules/
+package-lock.json

--- a/Phase2/package.json
+++ b/Phase2/package.json
@@ -36,6 +36,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
+        "apollo-server-express": "^3.12.0",
         "graphql-request": "^6.1.0",
         "graphql-ws": "^5.16.0",
         "node-fetch": "^3.3.2",

--- a/Phase2/server.js
+++ b/Phase2/server.js
@@ -6,8 +6,7 @@ import dotenv from 'dotenv'
 import { createServer as createViteServer } from 'vite'
 import path from 'path'
 import { fileURLToPath } from 'url'
-import { server as graphqlServer } from './server/graphql.js'
-import { queryWAXGraphQL } from './server/graphql.js'
+import { graphqlServer, queryWAXGraphQL } from './server/graphql.js'
 
 dotenv.config()
 
@@ -35,6 +34,7 @@ app.use('/assets', express.static(path.resolve(__dirname, 'public/assets')))
 app.use(express.json())
 
 // Mount Apollo-style GraphQL server (for your own schema)
+await graphqlServer.start()
 graphqlServer.applyMiddleware({ app })
 
 // ----------------------------------------

--- a/Phase2/server/graphql.js
+++ b/Phase2/server/graphql.js
@@ -147,7 +147,7 @@ const waxClient = createClient({
 });
 
 // WAX GraphQL query function
-async function queryWAXGraphQL(query, variables = {}) {
+export async function queryWAXGraphQL(query, variables = {}) {
     try {
         const result = await waxClient.request({
             query,
@@ -159,3 +159,5 @@ async function queryWAXGraphQL(query, variables = {}) {
         throw error;
     }
 }
+
+export { graphqlServer as server };


### PR DESCRIPTION
## Summary
- export `queryWAXGraphQL` and `server` from `graphql.js`
- import updated names in `server.js`
- start Apollo server before applying middleware
- include `apollo-server-express` dependency
- ignore `node_modules` and lockfile

## Testing
- `npm install --package-lock-only`
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_683f715eb550832a9917d126f8633e61