### PR TITLE
Fix WAX GraphQL export

### DIFF
--- a/Phase2/server/graphql.js
+++ b/Phase2/server/graphql.js
@@ -147,7 +147,7 @@ const waxClient = createClient({
 });
 
 // WAX GraphQL query function
-export async function queryWAXGraphQL(query, variables = {}) {
+async function queryWAXGraphQL(query, variables = {}) {
     try {
         const result = await waxClient.request({
             query,
@@ -161,3 +161,4 @@ export async function queryWAXGraphQL(query, variables = {}) {
 }
 
 export { graphqlServer as server };
+export { queryWAXGraphQL };


### PR DESCRIPTION
## Summary
- export `queryWAXGraphQL` from `Phase2/server/graphql.js` via named export at bottom
- keep `server.js` import using `queryWAXGraphQL`

## Testing
- `npm install`
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_683f744182c4832abcfd907c99404e0a