### PR TITLE
Add Jest tests for lore indexing

### DIFF
--- a/Phase2/package.json
+++ b/Phase2/package.json
@@ -10,7 +10,8 @@
         "start": "vite",
         "build": "vite build",
         "preview": "vite preview",
-        "server": "nodemon server.js"
+        "server": "nodemon server.js",
+        "test": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js"
     },
     "keywords": [
         "alien-worlds",
@@ -32,11 +33,11 @@
         "@wharfkit/contract": "^1.1.2",
         "@wharfkit/session": "^1.2.10",
         "@wharfkit/wallet-plugin-cloudwallet": "^1.0.3",
+        "apollo-server-express": "^3.12.0",
         "compression": "^1.7.4",
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
-        "apollo-server-express": "^3.12.0",
         "graphql-request": "^6.1.0",
         "graphql-ws": "^5.16.0",
         "node-fetch": "^3.3.2",
@@ -45,6 +46,7 @@
     "devDependencies": {
         "@vitejs/plugin-react": "^4.0.4",
         "buffer": "^6.0.3",
+        "jest": "^29.7.0",
         "nodemon": "^3.1.4",
         "process": "^0.11.10",
         "vite": "^6.3.5",

--- a/Phase2/test/loreIndex.test.js
+++ b/Phase2/test/loreIndex.test.js
@@ -1,0 +1,31 @@
+import { indexLore } from '../src/loreIndex.js';
+
+describe('indexLore', () => {
+  it('chunks content and extracts tags', () => {
+    const canonSections = [
+      { title: 'History', content: 'History about the mystical world of lore where heroes arise.' },
+      { title: 'Creation', content: 'Lore begins with the world creation. Many events shape the future. This is just an example to test chunking function.' }
+    ];
+
+    const proposedContents = [
+      {
+        title: 'Add characters',
+        prNumber: 42,
+        date: '2024-01-01',
+        sections: [
+          { title: 'New Heroes', content: 'Several brave characters join the lore in this update.', metadata: {} }
+        ]
+      }
+    ];
+
+    const index = indexLore(canonSections, proposedContents);
+
+    expect(index['canon-0'].chunks).toEqual([canonSections[0].content]);
+    expect(index['canon-1'].chunks).toEqual([canonSections[1].content]);
+    expect(index['proposed-42-0'].chunks).toEqual([proposedContents[0].sections[0].content]);
+
+    expect(index['canon-0'].tags).toEqual(expect.arrayContaining(['history', 'mystical', 'world', 'lore']));
+    expect(index['canon-1'].tags).toEqual(expect.arrayContaining(['lore', 'begins', 'world', 'creation']));
+    expect(index['proposed-42-0'].tags).toEqual(expect.arrayContaining(['characters', 'lore', 'brave']));
+  });
+});


### PR DESCRIPTION
## Summary
- install Jest and add test script
- create loreIndex Jest test verifying chunking and tag extraction

## Testing
- `npm test --prefix Phase2`

------
https://chatgpt.com/codex/tasks/task_e_683f7446152c832a978433020c8b49eb