### PR TITLE
Fix GitHub auth headers and live status UI

### DIFF
--- a/Phase1/server.js
+++ b/Phase1/server.js
@@ -8,19 +8,27 @@ const app = express();
 const PORT = 3000;
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
 
+function githubHeaders(accept) {
+    const headers = {
+        'Accept': accept,
+        'User-Agent': 'Alien-Worlds-Lore-App'
+    };
+    if (GITHUB_TOKEN) {
+        headers['Authorization'] = `Bearer ${GITHUB_TOKEN}`;
+    }
+    return headers;
+}
+
 // Serve static files from the 'public' directory
 app.use(express.static('public'));
 
 // Proxy endpoint for fetching Canon lore
 app.get('/api/canon', async (req, res) => {
     try {
-        const response = await fetch('https://api.github.com/repos/Alien-Worlds/the-lore/contents/README.md?ref=main', {
-            headers: {
-                'Accept': 'application/vnd.github.raw+json',
-                'Authorization': `Bearer ${GITHUB_TOKEN}`,
-                'User-Agent': 'Alien-Worlds-Lore-App'
-            }
-        });
+        const response = await fetch(
+            'https://api.github.com/repos/Alien-Worlds/the-lore/contents/README.md?ref=main',
+            { headers: githubHeaders('application/vnd.github.raw+json') }
+        );
         if (!response.ok) throw new Error(`HTTP ${response.status}`);
         const text = await response.text();
         res.send(text);
@@ -33,13 +41,10 @@ app.get('/api/canon', async (req, res) => {
 // Proxy endpoint for fetching Proposed lore
 app.get('/api/proposed', async (req, res) => {
     try {
-        const response = await fetch('https://api.github.com/repos/Alien-Worlds/the-lore/pulls?state=open&ref=main', {
-            headers: {
-                'Accept': 'application/vnd.github+json',
-                'Authorization': `Bearer ${GITHUB_TOKEN}`,
-                'User-Agent': 'Alien-Worlds-Lore-App'
-            }
-        });
+        const response = await fetch(
+            'https://api.github.com/repos/Alien-Worlds/the-lore/pulls?state=open&ref=main',
+            { headers: githubHeaders('application/vnd.github+json') }
+        );
         if (!response.ok) throw new Error(`HTTP ${response.status}`);
         const pulls = await response.json();
         res.json(pulls);
@@ -53,13 +58,10 @@ app.get('/api/proposed', async (req, res) => {
 app.get('/api/pulls/:number/files', async (req, res) => {
     const { number } = req.params;
     try {
-        const response = await fetch(`https://api.github.com/repos/Alien-Worlds/the-lore/pulls/${number}/files`, {
-            headers: {
-                'Accept': 'application/vnd.github+json',
-                'Authorization': `Bearer ${GITHUB_TOKEN}`,
-                'User-Agent': 'Alien-Worlds-Lore-App'
-            }
-        });
+        const response = await fetch(
+            `https://api.github.com/repos/Alien-Worlds/the-lore/pulls/${number}/files`,
+            { headers: githubHeaders('application/vnd.github+json') }
+        );
         if (!response.ok) throw new Error(`HTTP ${response.status}`);
         const files = await response.json();
         res.json(files);
@@ -74,11 +76,7 @@ app.get('/api/contents', async (req, res) => {
     const { url } = req.query;
     try {
         const response = await fetch(url, {
-            headers: {
-                'Accept': 'application/vnd.github.raw+json',
-                'Authorization': `Bearer ${GITHUB_TOKEN}`,
-                'User-Agent': 'Alien-Worlds-Lore-App'
-            }
+            headers: githubHeaders('application/vnd.github.raw+json')
         });
         if (!response.ok) throw new Error(`HTTP ${response.status}`);
         const content = await response.text();

--- a/Phase2/public/styles.css
+++ b/Phase2/public/styles.css
@@ -459,3 +459,9 @@ html, body {
         color: black;
     }
 }
+
+/* Live indicator styling */
+.live-indicator {
+    color: var(--success-color);
+    margin-left: 0.3em;
+}

--- a/Phase2/server.js
+++ b/Phase2/server.js
@@ -17,6 +17,17 @@ const app = express()
 const PORT = process.env.PORT || 3000
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN
 
+function githubHeaders(accept) {
+  const headers = {
+    Accept: accept,
+    'User-Agent': 'A01-Canon-Terminal'
+  }
+  if (GITHUB_TOKEN) {
+    headers['Authorization'] = `Bearer ${GITHUB_TOKEN}`
+  }
+  return headers
+}
+
 // Create Vite server in middleware mode
 const vite = await createViteServer({
   root: process.cwd(),
@@ -211,13 +222,7 @@ app.get('/api/proposed', async (req, res) => {
   try {
     const response = await fetch(
       'https://api.github.com/repos/Alien-Worlds/the-lore/pulls?state=open',
-      {
-        headers: {
-          'Accept': 'application/vnd.github+json',
-          'Authorization': `Bearer ${GITHUB_TOKEN}`,
-          'User-Agent': 'A01-Canon-Terminal'
-        }
-      }
+      { headers: githubHeaders('application/vnd.github+json') }
     )
 
     if (!response.ok) {
@@ -240,13 +245,7 @@ app.get('/api/pulls/:number/files', async (req, res) => {
   try {
     const response = await fetch(
       `https://api.github.com/repos/Alien-Worlds/the-lore/pulls/${number}/files`,
-      {
-        headers: {
-          'Accept': 'application/vnd.github+json',
-          'Authorization': `Bearer ${GITHUB_TOKEN}`,
-          'User-Agent': 'A01-Canon-Terminal'
-        }
-      }
+      { headers: githubHeaders('application/vnd.github+json') }
     )
     if (!response.ok) {
       console.error(`GitHub API Error (PR #${number} files): HTTP ${response.status}`)
@@ -268,11 +267,7 @@ app.get('/api/contents', async (req, res) => {
       return res.status(400).json({ error: 'Missing "url" query parameter' })
     }
     const response = await fetch(url, {
-      headers: {
-        'Accept': 'application/vnd.github.raw+json',
-        'Authorization': `Bearer ${GITHUB_TOKEN}`,
-        'User-Agent': 'A01-Canon-Terminal'
-      }
+      headers: githubHeaders('application/vnd.github.raw+json')
     })
     if (!response.ok) {
       console.error(`GitHub API Error (contents URL): HTTP ${response.status}`)

--- a/Phase2/src/graphql.js
+++ b/Phase2/src/graphql.js
@@ -2,7 +2,7 @@
 import { GraphQLClient } from 'graphql-request';
 
 // Create GraphQL client with proper URL
-const graphqlClient = new GraphQLClient('http://localhost:3000/graphql', {
+const graphqlClient = new GraphQLClient('/graphql', {
     headers: {
         'Content-Type': 'application/json',
     },


### PR DESCRIPTION
## Summary
- make GitHub API headers optional if a token isn't provided
- use relative URL for GraphQL client
- add style for live status indicator

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_683f7cab7b0c832abf714af07ca08fb5