### PR TITLE
Fix path for space explorer import

### DIFF
--- a/Phase2/src/ui.js
+++ b/Phase2/src/ui.js
@@ -6,7 +6,8 @@
  * - Section logic is modular and robust
  */
 
-import { showSpaceExplorer } from './space-explorer/js/space-explorer-integration.js';
+// Use the Vite alias so the path resolves correctly on all platforms
+import { showSpaceExplorer } from '@/space-explorer/js/space-explorer-integration.js';
 import { Library } from './library.js';
 import { UserProfile } from './profile.js';
 


### PR DESCRIPTION
## Summary
- use Vite alias `@` for space explorer import to avoid path resolution issues

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f864570dc832a905168b9fb4c3ff7