### PR TITLE
Add fallback for canon lore

### DIFF
--- a/Phase1/Public/fallback_canon.md
+++ b/Phase1/Public/fallback_canon.md
@@ -1,0 +1,4 @@
+# Fallback Canon Lore
+
+If you're seeing this, the server could not fetch the live lore from GitHub.
+This is placeholder content used for offline or testing environments.

--- a/Phase1/server.js
+++ b/Phase1/server.js
@@ -2,6 +2,8 @@
 const express = require('express');
 const dotenv = require('dotenv');
 const fetch = require('node-fetch');
+const fs = require('fs');
+const path = require('path');
 
 dotenv.config();
 const app = express();
@@ -34,7 +36,14 @@ app.get('/api/canon', async (req, res) => {
         res.send(text);
     } catch (error) {
         console.error('Error fetching Canon lore:', error);
-        res.status(500).send('Error fetching Canon lore');
+        try {
+            const fallbackPath = path.join(__dirname, 'Public', 'fallback_canon.md');
+            const text = fs.readFileSync(fallbackPath, 'utf8');
+            res.send(text);
+        } catch (fsErr) {
+            console.error('Error loading fallback canon lore:', fsErr);
+            res.status(500).send('Error fetching Canon lore');
+        }
     }
 });
 


### PR DESCRIPTION
## Summary
- add fallback markdown file when canonical lore fetch fails
- load fallback file instead of returning 500

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f89f33cb4832a842a7c7f740e2baa