### PR TITLE
Fix server fetching with offline fallback

### DIFF
--- a/Phase1/canon-fallback.md
+++ b/Phase1/canon-fallback.md
@@ -1,0 +1,11 @@
+# Sample Canon Lore
+
+This is sample Canon lore used when the server cannot fetch data from GitHub.
+
+## Origin Story
+
+In the early days, explorers ventured into the unknown reaches of space.
+
+## Factions
+
+Various factions formed alliances and rivalries shaping the universe.

--- a/Phase1/server.js
+++ b/Phase1/server.js
@@ -19,8 +19,9 @@ function githubHeaders(accept) {
     return headers;
 }
 
-// Serve static files from the 'public' directory
-app.use(express.static('public'));
+// Serve static files from the 'Public' directory
+// Using the correct case ensures the files are found on case‑sensitive systems
+app.use(express.static('Public'));
 
 // Proxy endpoint for fetching Canon lore
 app.get('/api/canon', async (req, res) => {
@@ -34,7 +35,14 @@ app.get('/api/canon', async (req, res) => {
         res.send(text);
     } catch (error) {
         console.error('Error fetching Canon lore:', error);
-        res.status(500).send('Error fetching Canon lore');
+        try {
+            const fs = require('fs');
+            const fallback = fs.readFileSync(__dirname + '/canon-fallback.md', 'utf8');
+            res.send(fallback);
+        } catch (fsError) {
+            console.error('Error loading fallback Canon lore:', fsError);
+            res.status(500).send('Error fetching Canon lore');
+        }
     }
 });
 
@@ -50,7 +58,8 @@ app.get('/api/proposed', async (req, res) => {
         res.json(pulls);
     } catch (error) {
         console.error('Error fetching Proposed lore:', error);
-        res.status(500).send('Error fetching Proposed lore');
+        // On failure return an empty array so the front-end can still render
+        res.json([]);
     }
 });
 


### PR DESCRIPTION
## Summary
- use the correct `Public` folder for static assets
- return local `canon-fallback.md` when GitHub fetch fails
- send an empty array on proposed lore fetch failure

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f8a1f4850832aa532dac064ed12a4