### PR TITLE
Feature upgrades for voting and markdown tools

### DIFF
--- a/Phase2/public/styles.css
+++ b/Phase2/public/styles.css
@@ -656,3 +656,9 @@ html, body {
 
 /* Markdown converter */
 .markdown-converter textarea { width:100%; height:8rem; margin-bottom:0.5rem; }
+.markdown-converter #md-preview { border:1px solid #555; padding:0.5rem; min-height:4rem; margin-top:0.5rem; }
+
+/* Voting UI */
+.vote-container { display:flex; flex-direction:column; gap:1rem; }
+.vote-card { border:1px solid #555; padding:0.5rem; border-radius:var(--border-radius); }
+.status-badge { padding:0 0.4rem; background:#333; border-radius:var(--border-radius); }

--- a/Phase2/src/markdownConverter.js
+++ b/Phase2/src/markdownConverter.js
@@ -7,16 +7,26 @@ export function showMarkdownConverter(containerId = 'contentBox') {
       <textarea id="md-input" placeholder="Paste raw text here"></textarea>
       <button id="md-convert">Convert</button>
       <textarea id="md-output" placeholder="Markdown output" readonly></textarea>
+      <div id="md-preview"></div>
     </div>
   `;
   const input = document.getElementById('md-input');
   const output = document.getElementById('md-output');
+  const preview = document.getElementById('md-preview');
   document.getElementById('md-convert').addEventListener('click', () => {
     output.value = simpleConvert(input.value);
+    preview.innerHTML = renderMarkdown(output.value);
   });
 }
 
 function simpleConvert(text) {
   const paragraphs = text.split(/\n\s*\n/).map(p => p.trim());
   return paragraphs.map(p => p ? p + '\n' : '').join('\n');
+}
+
+function renderMarkdown(text) {
+  return text
+    .replace(/(?:\*\*|__)(.*?)(?:\*\*|__)/g, '<strong>$1</strong>')
+    .replace(/(?:\*|_)(.*?)(?:\*|_)/g, '<em>$1</em>')
+    .replace(/\n/g, '<br>');
 }

--- a/Phase2/src/utils/bookmarks.js
+++ b/Phase2/src/utils/bookmarks.js
@@ -2,11 +2,15 @@ export function getBookmarks() {
   return JSON.parse(localStorage.getItem('bookmarks') || '[]');
 }
 
-export function toggleBookmark(sectionId) {
+export function toggleBookmark(section) {
   const bookmarks = getBookmarks();
-  const idx = bookmarks.indexOf(sectionId);
+  const idx = bookmarks.findIndex(b => b.id === section.sectionId);
   if (idx === -1) {
-    bookmarks.push(sectionId);
+    bookmarks.push({
+      id: section.sectionId,
+      title: section.title,
+      pr: section.prNumber || null
+    });
   } else {
     bookmarks.splice(idx, 1);
   }
@@ -14,5 +18,5 @@ export function toggleBookmark(sectionId) {
 }
 
 export function isBookmarked(sectionId) {
-  return getBookmarks().includes(sectionId);
+  return getBookmarks().some(b => b.id === sectionId);
 }


### PR DESCRIPTION
## Summary
- add flexible filtering with `tag:` and `author:` keywords
- store bookmark metadata and update bookmark UI
- enhance Markdown converter with preview rendering
- build vote dashboard using `graphqlMegaFetcher`
- style voting widgets and preview box

## Testing
- `npm install --prefix Phase2`
- `npm test --prefix Phase2`

------
https://chatgpt.com/codex/tasks/task_e_684935547b9c832aa5a7bd6a9fc30982