### PR TITLE
Implement initial Lore Terminal

### DIFF
--- a/api/alienworlds.js
+++ b/api/alienworlds.js
@@ -1,0 +1,5 @@
+export async function fetchCanonLore() {
+  const res = await fetch('https://alienworlds-api.com/lore/canon');
+  const data = await res.json();
+  return data;
+}

--- a/api/github.js
+++ b/api/github.js
@@ -1,0 +1,5 @@
+export async function fetchProposedLore() {
+  const res = await fetch('https://api.github.com/repos/Alien-Worlds/the-lore/pulls');
+  const data = await res.json();
+  return data.map(pr => ({ id: pr.number, title: pr.title, body: pr.body, status: pr.state }));
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Lore Terminal</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <script type="module" src="terminal.js"></script>
+</body>
+</html>

--- a/loreParser.js
+++ b/loreParser.js
@@ -1,0 +1,9 @@
+export function renderMarkdown(md = '') {
+  return md
+    .replace(/^### (.*$)/gim, '<h3>$1</h3>')
+    .replace(/^## (.*$)/gim, '<h2>$1</h2>')
+    .replace(/^# (.*$)/gim, '<h1>$1</h1>')
+    .replace(/\*\*(.*)\*\*/gim, '<b>$1</b>')
+    .replace(/\*(.*)\*/gim, '<i>$1</i>')
+    .replace(/\n$/gim, '<br />');
+}

--- a/markdownHelper.js
+++ b/markdownHelper.js
@@ -1,0 +1,17 @@
+function convertToMarkdown(raw) {
+  return raw
+    .replace(/\n{2,}/g, '\n\n')
+    .replace(/\t/g, '    ');
+}
+
+document.body.insertAdjacentHTML('beforeend', `
+  <textarea id="inputText" placeholder="Paste text here..."></textarea>
+  <button id="convertBtn">Convert to Markdown</button>
+  <pre id="mdOutput"></pre>
+`);
+
+document.getElementById('convertBtn').onclick = () => {
+  const raw = document.getElementById('inputText').value;
+  const md = convertToMarkdown(raw);
+  document.getElementById('mdOutput').textContent = md;
+};

--- a/style.css
+++ b/style.css
@@ -1,0 +1,39 @@
+body {
+  background: black;
+  color: white;
+  font-family: monospace;
+  margin: 0;
+  padding: 0;
+}
+
+#terminal {
+  padding: 1rem;
+  position: relative;
+  min-height: 100vh;
+}
+
+.scanline::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: repeating-linear-gradient(transparent 1px, rgba(255,255,255,0.03) 2px);
+  pointer-events: none;
+}
+
+header, footer {
+  text-align: center;
+}
+
+nav {
+  margin-bottom: 1rem;
+}
+
+#loreDisplay {
+  white-space: pre-wrap;
+}
+
+pre {
+  background: #111;
+  padding: 1rem;
+  overflow-x: auto;
+}

--- a/terminal.js
+++ b/terminal.js
@@ -1,0 +1,41 @@
+import { renderMarkdown } from './loreParser.js';
+import { fetchProposedLore } from './api/github.js';
+import { fetchCanonLore } from './api/alienworlds.js';
+import './ui/filters.js';
+import './ui/menu.js';
+import './ui/bookmarks.js';
+import './ui/comments.js';
+import './ui/modal.js';
+import { displayVoteButtons } from './voteSystem.js';
+
+async function load() {
+  document.body.innerHTML = `
+    <div id="terminal" class="scanline">
+      <header><h1>ALIEN WORLDS: LORE TERMINAL</h1></header>
+      <nav id="menu"></nav>
+      <div id="filters"></div>
+      <section id="loreDisplay"></section>
+      <footer>v1.0 - loreworks.co.za</footer>
+    </div>`;
+
+  const canon = await fetchCanonLore().catch(() => []);
+  const proposed = await fetchProposedLore().catch(() => []);
+  const allLore = [...canon, ...proposed];
+  displayLore(allLore);
+}
+
+function displayLore(items) {
+  const container = document.getElementById('loreDisplay');
+  container.innerHTML = items
+    .map(item => `<article data-id="${item.id || item.title}">${displayVoteButtons(item.id || item.title)}${renderMarkdown(item.body || item.content)}</article>`)
+    .join('\n');
+}
+
+window.filterLore = term => {
+  const articles = document.querySelectorAll('#loreDisplay article');
+  articles.forEach(a => {
+    a.style.display = a.textContent.toLowerCase().includes(term) ? '' : 'none';
+  });
+};
+
+load();

--- a/ui/bookmarks.js
+++ b/ui/bookmarks.js
@@ -1,0 +1,6 @@
+let bookmarks = JSON.parse(localStorage.getItem('bookmarks')) || [];
+
+window.addBookmark = id => {
+  if (!bookmarks.includes(id)) bookmarks.push(id);
+  localStorage.setItem('bookmarks', JSON.stringify(bookmarks));
+};

--- a/ui/comments.js
+++ b/ui/comments.js
@@ -1,0 +1,6 @@
+const comments = {};
+
+export function addComment(id, text) {
+  if (!comments[id]) comments[id] = [];
+  comments[id].push(text);
+}

--- a/ui/filters.js
+++ b/ui/filters.js
@@ -1,0 +1,16 @@
+const filters = document.getElementById('filters');
+if (filters) {
+  filters.innerHTML = `
+    <input id="searchInput" placeholder="Search lore...">
+    <select id="categorySelect">
+      <option>All</option>
+      <option>Planets</option>
+      <option>Factions</option>
+    </select>
+  `;
+
+  document.getElementById('searchInput').addEventListener('input', e => {
+    const term = e.target.value.toLowerCase();
+    window.filterLore(term);
+  });
+}

--- a/ui/menu.js
+++ b/ui/menu.js
@@ -1,0 +1,4 @@
+const menu = document.getElementById('menu');
+if (menu) {
+  menu.innerHTML = '[Planets] [Factions] [Species] [Technology]';
+}

--- a/ui/modal.js
+++ b/ui/modal.js
@@ -1,0 +1,7 @@
+export function showModal(content) {
+  const div = document.createElement('div');
+  div.id = 'modal';
+  div.innerHTML = `<div class="content">${content}</div>`;
+  document.body.appendChild(div);
+  div.addEventListener('click', () => div.remove());
+}

--- a/voteSystem.js
+++ b/voteSystem.js
@@ -1,0 +1,14 @@
+let votes = JSON.parse(localStorage.getItem('votes')) || {};
+
+export function displayVoteButtons(loreId) {
+  return `
+    <button onclick="vote('${loreId}','yes')">👍</button>
+    <button onclick="vote('${loreId}','no')">👎</button>
+  `;
+}
+
+window.vote = (id, choice) => {
+  votes[id] = choice;
+  localStorage.setItem('votes', JSON.stringify(votes));
+  alert(`Voted ${choice.toUpperCase()} on ${id}`);
+};


### PR DESCRIPTION
## Summary
- add HTML skeleton and main JS entry
- implement retro styling
- fetch lore from GitHub and Alien Worlds APIs
- render simple markdown and voting buttons
- add UI helpers for menu, filtering, bookmarks, and comments
- include markdown conversion helper and placeholder assets

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_6852bdbf91c0832a996523a6745dda65