### PR TITLE
Improve error handling and use live data

### DIFF
--- a/Phase2/server.js
+++ b/Phase2/server.js
@@ -69,32 +69,18 @@ app.post('/api/aw-query', async (req, res) => {
 // 2. Canon lore via your own GraphQL schema
 app.get('/api/canon', async (req, res) => {
   try {
-    const result = await graphqlServer.executeOperation({
-      query: `
-        query {
-          lore {
-            id
-            title
-            content
-            author
-            date
-            category
-          }
-        }
-      `
-    })
-
-    if (result.errors) {
-      console.error('GraphQL errors in /api/canon:', result.errors)
-      return res.status(500).json({ error: 'GraphQL returned errors' })
+    const response = await fetch(
+      'https://api.github.com/repos/Alien-Worlds/the-lore/contents/README.md?ref=main',
+      { headers: githubHeaders('application/vnd.github.raw+json') }
+    )
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`)
     }
-
-    // Extract data.lore
-    const lore = result.data?.lore || []
-    res.json(lore)
+    const text = await response.text()
+    res.send(text)
   } catch (error) {
     console.error('Error fetching canon lore:', error)
-    res.status(500).json({ error: 'Failed to fetch canon lore' })
+    res.status(500).send('Error fetching Canon lore')
   }
 })
 

--- a/Phase2/server/graphql.js
+++ b/Phase2/server/graphql.js
@@ -61,67 +61,14 @@ const typeDefs = gql`
     }
 `;
 
-// Mock data for development
-const mockData = {
-    lore: [
-        {
-            id: '1',
-            title: 'The Beginning',
-            content: 'In the vast expanse of space, the Alien Worlds project began...',
-            category: 'history',
-            timestamp: new Date().toISOString()
-        }
-    ],
-    planets: {
-        'Eyeke': {
-            name: 'Eyeke',
-            type: 'Terrestrial',
-            climate: 'Temperate',
-            resources: ['Trilium', 'Kyanite'],
-            natives: [
-                {
-                    species: 'Humanoid Colonists',
-                    population: 1000000,
-                    intelligence: 8
-                }
-            ]
-        }
-    },
-    races: [
-        {
-            id: '1',
-            name: 'Humans',
-            description: 'The most adaptable species in the galaxy...',
-            traits: ['Adaptable', 'Curious', 'Resourceful'],
-            homeworld: 'Earth'
-        }
-    ],
-    technology: [
-        {
-            id: '1',
-            name: 'Warp Drive',
-            description: 'Enables faster-than-light travel...',
-            level: 5,
-            requirements: ['Advanced Materials', 'Energy Core']
-        }
-    ],
-    userProfile: {
-        username: 'TestUser',
-        wallet: 'testuser123',
-        contributions: 42,
-        votes: 105,
-        planetsVisited: 7
-    }
-};
-
-// Define resolvers
+// Placeholder resolvers - replace with real data sources
 const resolvers = {
     Query: {
-        lore: () => mockData.lore,
-        planet: (_, { name }) => mockData.planets[name],
-        races: () => mockData.races,
-        technology: () => mockData.technology,
-        userProfile: () => mockData.userProfile
+        lore: () => [],
+        planet: () => null,
+        races: () => [],
+        technology: () => [],
+        userProfile: () => null
     }
 };
 

--- a/Phase2/src/graphqlMegaFetcher.js
+++ b/Phase2/src/graphqlMegaFetcher.js
@@ -88,7 +88,11 @@ export async function fetchMegaProfile(wallet, dacId, planetId) {
       body: JSON.stringify({ query, variables })
     });
 
-    // Attempt to parse JSON response directly
+    if (!response.ok) {
+      const text = await response.text().catch(() => '');
+      throw new Error(`Server responded ${response.status} ${response.statusText}: ${text}`);
+    }
+
     const json = await response.json();
 
     // Safely extract nested response data


### PR DESCRIPTION
## Summary
- handle HTTP errors in `fetchMegaProfile`
- fetch canon lore directly from GitHub instead of mock GraphQL data
- remove mock data usage from GraphQL server

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68403b0fe80c832aa27ec18270c9b29f